### PR TITLE
Block description open links

### DIFF
--- a/PropertiesPanel/BlockPropertiesPanel.cpp
+++ b/PropertiesPanel/BlockPropertiesPanel.cpp
@@ -202,7 +202,8 @@ BlockPropertiesPanel::BlockPropertiesPanel(GraphBlock *block, QWidget *parent):
         _blockInfoDesc->setStyleSheet("QLabel{background:white;margin:1px;}");
         _blockInfoDesc->setWordWrap(true);
         _blockInfoDesc->setAlignment(Qt::AlignTop | Qt::AlignLeft);
-        _blockInfoDesc->setTextInteractionFlags(Qt::TextSelectableByMouse);
+        _blockInfoDesc->setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::LinksAccessibleByMouse);
+        _blockInfoDesc->setOpenExternalLinks(true);
         _infoTabs->addTab(_blockInfoDesc, tr("Documentation"));
     }
 

--- a/PropertiesPanel/BlockPropertiesPanel.cpp
+++ b/PropertiesPanel/BlockPropertiesPanel.cpp
@@ -204,6 +204,7 @@ BlockPropertiesPanel::BlockPropertiesPanel(GraphBlock *block, QWidget *parent):
         _blockInfoDesc->setAlignment(Qt::AlignTop | Qt::AlignLeft);
         _blockInfoDesc->setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::LinksAccessibleByMouse);
         _blockInfoDesc->setOpenExternalLinks(true);
+        connect(_blockInfoDesc, &QLabel::linkHovered, _blockInfoDesc, &QLabel::setToolTip);
         _infoTabs->addTab(_blockInfoDesc, tr("Documentation"));
     }
 


### PR DESCRIPTION
Hi, I was added external links to the documentation of a block am working on and I noticed the QLabel for block description would not open the link or allow me to copy the URL.
I have created this patch which allows QLabel to copy the link or open it. It also show the full URL in a tooltip when hovered over.
Not sure if this is usefully, but I thought I would share it anyway.
