### PR TITLE
WIP: Port to Qt5.15/Qt6

### DIFF
--- a/AffinitySupport/CpuSelectionWidget.cpp
+++ b/AffinitySupport/CpuSelectionWidget.cpp
@@ -99,7 +99,7 @@ void CpuSelectionWidget::update(void)
     {
         if (numaNodeSelected and _cpuItems.count(pair.first) != 0) pair.first->setFlags(Qt::NoItemFlags);
         else pair.first->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
-        pair.first->setBackgroundColor((pair.second)?Qt::green:Qt::white);
+        pair.first->setBackground((pair.second)?Qt::green:Qt::white);
         pair.first->setSelected(false);
     }
 

--- a/BlockTree/BlockTreeWidget.cpp
+++ b/BlockTree/BlockTreeWidget.cpp
@@ -90,7 +90,6 @@ void BlockTreeWidget::mouseMoveEvent(QMouseEvent *event)
     painter.translate(-bounds.topLeft()+QPoint(1,1));
     //painter.scale(zoomScale, zoomScale); //TODO get zoomscale from draw
     painter.setRenderHint(QPainter::Antialiasing);
-    painter.setRenderHint(QPainter::HighQualityAntialiasing);
     painter.setRenderHint(QPainter::SmoothPixmapTransform);
     renderBlock->render(painter);
     renderBlock.reset();
@@ -98,8 +97,7 @@ void BlockTreeWidget::mouseMoveEvent(QMouseEvent *event)
 
     //create the drag object
     auto mimeData = new QMimeData();
-    const QJsonDocument jsonDoc(blockItem->getBlockDesc());
-    mimeData->setData("binary/json/pothos_block", jsonDoc.toBinaryData());
+    mimeData->setData("binary/json/pothos_block", QJsonDocument::fromVariant(blockItem->getBlockDesc()).toJson());
     auto drag = new QDrag(this);
     drag->setMimeData(mimeData);
     drag->setPixmap(pixmap);
@@ -200,8 +198,7 @@ QMimeData *BlockTreeWidget::mimeData(const QList<QTreeWidgetItem *> items) const
         auto b = dynamic_cast<BlockTreeWidgetItem *>(item);
         if (b == nullptr) continue;
         auto mimeData = new QMimeData();
-        const QJsonDocument jsonDoc(b->getBlockDesc());
-        mimeData->setData("binary/json/pothos_block", jsonDoc.toBinaryData());
+        mimeData->setData("binary/json/pothos_block", QJsonDocument::fromVariant(b->getBlockDesc()).toJson());
         return mimeData;
     }
     return QTreeWidget::mimeData(items);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,10 @@
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 2.8.9)
+
+cmake_minimum_required(VERSION 3.20)
+add_compile_definitions(QT_DISABLE_DEPRECATED_BEFORE=0x050F00)
+set(CMAKE_CXX_STANDARD 17)
 project(PothosFlow CXX)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
@@ -19,17 +22,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 include_directories(${Pothos_INCLUDE_DIRS})
 
 ########################################################################
-# QT4 devel setup
-########################################################################
-#find_package(Qt4 COMPONENTS QtCore QtGui)
-#if(NOT QT4_FOUND)
-#    return()
-#endif()
-#include(${QT_USE_FILE})
-#list(APPEND Pothos_LIBRARIES ${QT_LIBRARIES})
-
-########################################################################
-# QT5 devel setup
+# QT5/QT6 devel setup
 ########################################################################
 #http://www.kdab.com/using-cmake-with-qt-5/
 # Tell CMake to run moc when necessary:
@@ -38,17 +31,23 @@ set(CMAKE_AUTOMOC ON)
 # to always look for includes there:
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-# Widgets finds its own dependencies.
-find_package(Qt5Widgets)
-
-if(Qt5Widgets_FOUND)
-    include_directories(${Qt5Widgets_INCLUDE_DIRS})
-    add_definitions(${Qt5Widgets_DEFINITIONS})
-    list(APPEND Pothos_LIBRARIES ${Qt5Widgets_LIBRARIES})
+find_package(Qt6Widgets)
+if (NOT Qt6Widgets_FOUND)
+	find_package(Qt5Widgets)
+	if(Qt5Widgets_FOUND)
+	    include_directories(${Qt5Widgets_INCLUDE_DIRS})
+	    add_definitions(${Qt5Widgets_DEFINITIONS})
+	    list(APPEND Pothos_LIBRARIES ${Qt5Widgets_LIBRARIES})
+	endif()
+	find_package(Qt5Concurrent)
+else()
+	include_directories(${Qt6Widgets_INCLUDE_DIRS})
+	add_definitions(${Qt6Widgets_DEFINITIONS})
+	list(APPEND Pothos_LIBRARIES ${Qt6Widgets_LIBRARIES})
+	find_package(Qt6Concurrent)
 endif()
 
 # Widgets finds its own dependencies.
-find_package(Qt5Concurrent)
 
 if(Qt5Concurrent_FOUND)
     include_directories(${Qt5Concurrent_INCLUDE_DIRS})

--- a/EditWidgets/ColorPicker.cpp
+++ b/EditWidgets/ColorPicker.cpp
@@ -53,7 +53,7 @@ public slots:
     void setValue(const QString &value)
     {
         if (_value.size() < 2) return;
-        _value = value.midRef(1, value.size()-2).toString();
+        _value = QStringView{value}.mid(1, value.size()-2).toString();
         QtColorPicker::setCurrentColor(_value);
     }
 

--- a/EditWidgets/DTypeChooser.cpp
+++ b/EditWidgets/DTypeChooser.cpp
@@ -118,7 +118,7 @@ private:
     {
         if (s.startsWith("\"") and s.endsWith("\""))
         {
-            return s.midRef(1, s.size()-2).toString();
+            return QStringView{s}.mid(1, s.size()-2).toString();
         }
         return s;
     }

--- a/EditWidgets/FileEntry.cpp
+++ b/EditWidgets/FileEntry.cpp
@@ -45,7 +45,7 @@ public slots:
     {
         if (s.startsWith("\"") and s.endsWith("\""))
         {
-            auto s0 = s.midRef(1, s.size()-2).toString();
+            auto s0 = QStringView{s}.mid(1, s.size()-2).toString();
             _edit->setText(s0.replace("\\\"", "\"")); //unescape
         }
         else _edit->setText(s);

--- a/EditWidgets/StringEntry.cpp
+++ b/EditWidgets/StringEntry.cpp
@@ -31,7 +31,7 @@ public slots:
     {
         if (s.startsWith("\"") and s.endsWith("\""))
         {
-            auto s0 = s.midRef(1, s.size()-2).toString();
+            auto s0 = QStringView{s}.mid(1, s.size()-2).toString();
             QLineEdit::setText(s0.replace("\\\"", "\"")); //unescape
         }
         else QLineEdit::setText(s);

--- a/EditWidgets/ToggleSwitch.cpp
+++ b/EditWidgets/ToggleSwitch.cpp
@@ -101,7 +101,6 @@ protected:
         const int h = this->height();
         const auto &palette = this->palette();
         p.setRenderHint(QPainter::Antialiasing);
-        p.setRenderHint(QPainter::HighQualityAntialiasing);
         p.setRenderHint(QPainter::SmoothPixmapTransform);
 
         //the border color to show selection
@@ -130,8 +129,8 @@ protected:
 
     void wheelEvent(QWheelEvent *e)
     {
-        const bool checked = e->delta() > 0;
-        if (e->delta() != 0 and checked != this->isChecked())
+        const bool checked = e->angleDelta().y() > 0;
+        if (e->angleDelta().y() != 0 and checked != this->isChecked())
         {
             this->setChecked(checked);
             this->handleToggled(checked);

--- a/EvalEngine/BlockEval.cpp
+++ b/EvalEngine/BlockEval.cpp
@@ -14,7 +14,7 @@
 #include <cassert>
 #include <iostream>
 #include <QApplication>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QSet>
 
 //! Number of milliseconds until the overlay is considered expired
@@ -250,7 +250,7 @@ bool BlockEval::evaluationProcedure(void)
     {
         _lastBlockStatus.blockErrorMsgs.push_back(tr("Error: empty ID"));
     }
-    else if (_newBlockInfo.id.count(QRegExp("^[a-zA-Z]\\w*$")) != 1)
+    else if (_newBlockInfo.id.count(QRegularExpression("^[a-zA-Z]\\w*$")) != 1)
     {
         _lastBlockStatus.blockErrorMsgs.push_back(
             tr("'%1' is not a legal ID").arg(_newBlockInfo.id));
@@ -508,7 +508,7 @@ QStringList BlockEval::getConstantsUsed(const QString &expr, const size_t depth)
 
     //create a recursive list of used constants by traversing expressions
     QStringList used;
-    for (const auto &tok : expr.split(QRegExp("\\W"), QString::SkipEmptyParts))
+    for (const auto &tok : expr.split(QRegularExpression("\\W"), Qt::SkipEmptyParts))
     {
         //is this token a constant? then inspect it
         if (_newBlockInfo.constants.count(tok) != 0)
@@ -582,7 +582,7 @@ bool BlockEval::applyConstants(void)
 {
     EVAL_TRACER_FUNC();
     //determine which constants were removed from the last eval
-    auto removedConstants = _lastBlockInfo.constantNames.toSet();
+    QSet<QString> removedConstants(_lastBlockInfo.constantNames.begin(), _lastBlockInfo.constantNames.end());
     for (const auto &name : _newBlockInfo.constantNames)
     {
         removedConstants.remove(name);

--- a/EvalEngine/EvalEngineImpl.cpp
+++ b/EvalEngine/EvalEngineImpl.cpp
@@ -181,9 +181,10 @@ void EvalEngineImpl::evaluate(void)
     EvalTracer::install(_tracer); //needed here to install the tracer
     EVAL_TRACER_FUNC();
 
-    //Do not evaluate when there are pending events in the queue.
-    //Evaluate only after all events received - AKA event compression.
-    if (this->thread()->eventDispatcher()->hasPendingEvents()) return;
+    // //Do not evaluate when there are pending events in the queue.
+    // //Evaluate only after all events received - AKA event compression.
+    // if (this->thread()->eventDispatcher()->hasPendingEvents()) return;
+    // // FIXME: these APIs are deprecated going forward.
 
     //Only evaluate if require evaluate was flagged by a slot
     if (not _requireEval) return;

--- a/GraphEditor/DockingTabWidget.cpp
+++ b/GraphEditor/DockingTabWidget.cpp
@@ -322,7 +322,7 @@ void DockingTabWidget::restoreWidgetState(const QVariant &state)
     if (data.isEmpty()) return;
     this->setCurrentIndex(data["index"].toInt());
     const auto tabs = data["tabs"].toList();
-    for (int index = 0; index < std::min(tabs.size(), this->count()); index++)
+    for (int index = 0; index < std::min(static_cast<int>(tabs.size()), this->count()); index++)
     {
         const auto tabData = tabs[index].toMap();
         this->page(index)->setDocked(tabData["docked"].toBool());

--- a/GraphEditor/GraphDraw.cpp
+++ b/GraphEditor/GraphDraw.cpp
@@ -46,7 +46,6 @@ GraphDraw::GraphDraw(QWidget *parent):
 
     //set high quality rendering
     this->setRenderHint(QPainter::Antialiasing);
-    this->setRenderHint(QPainter::HighQualityAntialiasing);
     this->setRenderHint(QPainter::SmoothPixmapTransform);
 
     //init settings
@@ -127,8 +126,15 @@ void GraphDraw::dragMoveEvent(QDragMoveEvent *event)
 void GraphDraw::dropEvent(QDropEvent *event)
 {
     const auto byteArray = event->mimeData()->data("binary/json/pothos_block");
-    const auto blockDesc = QJsonDocument::fromBinaryData(byteArray).object();
-    this->getGraphEditor()->handleAddBlock(blockDesc, this->mapToScene(event->pos()), this);
+    QJsonParseError err;
+    const auto blockDesc = QJsonDocument::fromJson(byteArray, &err);
+    if (blockDesc.isNull() or !blockDesc.isObject()) {
+	// fixme: pull logger into this file and log info from `err`.
+        return;
+    }
+    const auto obj = blockDesc.object();
+
+    this->getGraphEditor()->handleAddBlock(obj, this->mapToScene(event->pos()), this);
     event->acceptProposedAction();
 }
 

--- a/GraphEditor/GraphDrawSelection.cpp
+++ b/GraphEditor/GraphDrawSelection.cpp
@@ -46,8 +46,8 @@ void GraphDraw::wheelEvent(QWheelEvent *event)
 
     //ctrl was down, wheel event means zoom in or out:
     auto actions = MainActions::global();
-    if (event->delta() > 0) actions->zoomInAction->activate(QAction::Trigger);
-    if (event->delta() < 0) actions->zoomOutAction->activate(QAction::Trigger);
+    if (event->angleDelta().y() > 0) actions->zoomInAction->activate(QAction::Trigger);
+    if (event->angleDelta().y() < 0) actions->zoomOutAction->activate(QAction::Trigger);
 }
 
 void GraphDraw::mousePressEvent(QMouseEvent *event)

--- a/GraphEditor/GraphEditorSerialization.cpp
+++ b/GraphEditor/GraphEditorSerialization.cpp
@@ -56,7 +56,7 @@ QByteArray GraphEditor::dumpState(void) const
         {
             auto draw = this->getGraphDraw(pageNo);
             auto objs = draw->getGraphObjects(graphType);
-            qSort(objs.begin(), objs.end(), [](const GraphObject *lhs, const GraphObject *rhs)
+            std::sort(objs.begin(), objs.end(), [](const GraphObject *lhs, const GraphObject *rhs)
             {
                 return QString::compare(lhs->getId(), rhs->getId()) < 0;
             });

--- a/GraphObjects/GraphWidgetContainer.cpp
+++ b/GraphObjects/GraphWidgetContainer.cpp
@@ -120,7 +120,11 @@ void GraphWidgetContainer::setSelected(const bool selected)
         .arg(GraphWidgetBackgroundColor));
 }
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 void GraphWidgetContainer::enterEvent(QEvent *event)
+#else
+void GraphWidgetContainer::enterEvent(QEnterEvent *event)
+#endif
 {
     this->updateShowGrip();
     QWidget::enterEvent(event);

--- a/GraphObjects/GraphWidgetContainer.hpp
+++ b/GraphObjects/GraphWidgetContainer.hpp
@@ -43,7 +43,11 @@ signals:
     void resized(void);
 
 protected:
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     void enterEvent(QEvent *event);
+#else
+    void enterEvent(QEnterEvent *event);
+#endif
     void leaveEvent(QEvent *event);
     void updateShowGrip(void);
     void paintEvent(QPaintEvent *event);

--- a/MainWindow/MainSplash.cpp
+++ b/MainWindow/MainSplash.cpp
@@ -12,8 +12,8 @@ MainSplash *MainSplash::global(void)
     return globalMainSplash;
 }
 
-MainSplash::MainSplash(QWidget *parent):
-    QSplashScreen(parent, QPixmap(makeIconPath("PothosSplash.png")))
+MainSplash::MainSplash():
+    QSplashScreen(QPixmap(makeIconPath("PothosSplash.png")))
 {
     globalMainSplash = this;
 }

--- a/MainWindow/MainSplash.hpp
+++ b/MainWindow/MainSplash.hpp
@@ -16,7 +16,7 @@ public:
     //! Global access to main splash
     static MainSplash *global(void);
 
-    MainSplash(QWidget *parent);
+    MainSplash();
 
     void postMessage(const QString &msg);
 };

--- a/MainWindow/MainWindow.cpp
+++ b/MainWindow/MainWindow.cpp
@@ -34,7 +34,7 @@ MainWindow *MainWindow::global(void)
 MainWindow::MainWindow(QWidget *parent):
     QMainWindow(parent),
     _logger(Poco::Logger::get("PothosFlow.MainWindow")),
-    _splash(new MainSplash(this)),
+    _splash(new MainSplash()),
     _settings(new MainSettings(this)),
     _actions(nullptr),
     _blockCache(nullptr),

--- a/MessageWindow/LoggerDisplay.cpp
+++ b/MessageWindow/LoggerDisplay.cpp
@@ -99,7 +99,11 @@ void LoggerDisplay::resizeEvent(QResizeEvent *event)
     return QStackedWidget::resizeEvent(event);
 }
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 void LoggerDisplay::enterEvent(QEvent *event)
+#else
+void LoggerDisplay::enterEvent(QEnterEvent *event)
+#endif
 {
     _clearButton->show();
     _clearButton->move(_text->viewport()->width()-_clearButton->width(), 0);

--- a/MessageWindow/LoggerDisplay.hpp
+++ b/MessageWindow/LoggerDisplay.hpp
@@ -30,7 +30,11 @@ private:
     QToolButton *_clearButton;
     QTimer *_timer;
 
-    void resizeEvent(QResizeEvent *event);
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     void enterEvent(QEvent *event);
+#else
+    void enterEvent(QEnterEvent *event);
+#endif
+    void resizeEvent(QResizeEvent *event);
     void leaveEvent(QEvent *event);
 };

--- a/PropertiesPanel/BlockPropertiesPanel.cpp
+++ b/PropertiesPanel/BlockPropertiesPanel.cpp
@@ -137,7 +137,6 @@ BlockPropertiesPanel::BlockPropertiesPanel(GraphBlock *block, QWidget *parent):
         QPainter painter(&pixmap);
         painter.translate(-bounds.topLeft()+QPoint(1,1));
         painter.setRenderHint(QPainter::Antialiasing);
-        painter.setRenderHint(QPainter::HighQualityAntialiasing);
         painter.setRenderHint(QPainter::SmoothPixmapTransform);
         _block->render(painter);
         painter.end();

--- a/PropertiesPanel/GraphPropertiesPanel.cpp
+++ b/PropertiesPanel/GraphPropertiesPanel.cpp
@@ -232,7 +232,8 @@ QStringList GraphPropertiesPanel::getChangeDescList(void) const
     //look for reorder of variable list
     if (
         _originalVariableNames != _graphEditor->listGlobals() and
-        QSet<QString>::fromList(_originalVariableNames) == QSet<QString>::fromList(_graphEditor->listGlobals())
+        QSet<QString>(_originalVariableNames.begin(), _originalVariableNames.end()) ==
+        QSet<QString>(_graphEditor->listGlobals().begin(), _graphEditor->listGlobals().end())
     )
     {
         changes.push_back(tr("Reordered variables"));
@@ -288,7 +289,7 @@ void GraphPropertiesPanel::handleCreateVariable(void)
     QString errorMsg;
 
     //check for a legal variable name
-    if (name.count(QRegExp("^[a-zA-Z]\\w*$")) != 1)
+    if (name.count(QRegularExpression("^[a-zA-Z]\\w*$")) != 1)
     {
         errorMsg = tr("'%1' is not a legal variable name").arg(name);
     }

--- a/qtcolorpicker/src/qtcolorpicker.cpp
+++ b/qtcolorpicker/src/qtcolorpicker.cpp
@@ -45,7 +45,6 @@
 ****************************************************************************/
 
 #include <QApplication>
-#include <QDesktopWidget>
 #include <QPainter>
 #include <QPushButton>
 #include <QColorDialog>
@@ -60,6 +59,7 @@
 #include <QGridLayout>
 #include <QHideEvent>
 #include <QKeyEvent>
+#include <QScreen>
 #include <QShowEvent>
 #include <QMouseEvent>
 #include <math.h>
@@ -168,7 +168,7 @@ class ColorPickerItem : public QFrame
     Q_OBJECT
 
 public:
-    ColorPickerItem(const QColor &color = Qt::white, const QString &text = QString::null,
+    ColorPickerItem(const QColor &color = Qt::white, const QString &text = QString(),
 		      QWidget *parent = 0);
     ~ColorPickerItem();
 
@@ -309,8 +309,8 @@ void QtColorPicker::buttonPressed(bool toggled)
 {
     if (!toggled)
         return;
-
-    const QRect desktop = QApplication::desktop()->geometry();
+    const QScreen* qscr = QApplication::primaryScreen();
+    const QRect desktop = qscr->geometry();
     // Make sure the popup is inside the desktop.
     QPoint pos = mapToGlobal(rect().bottomLeft());
     if (pos.x() < desktop.left())
@@ -859,7 +859,7 @@ void ColorPickerPopup::regenerateGrid()
     // one.
     if (grid) delete grid;
     grid = new QGridLayout(this);
-    grid->setMargin(1);
+    grid->setContentsMargins(1,1,1,1);
     grid->setSpacing(0);
 
     int ccol = 0, crow = 0;
@@ -888,12 +888,14 @@ void ColorPickerPopup::regenerateGrid()
 */
 void ColorPickerPopup::getColorFromDialog()
 {
-    bool ok;
-    QRgb rgb = QColorDialog::getRgba(lastSel.rgba(), &ok, parentWidget());
-    if (!ok)
+    QColor col = QColorDialog::getColor(
+		    lastSel, parentWidget(),
+		    QString("Select a color"),
+		    QColorDialog::ShowAlphaChannel);
+
+    if (!col.isValid())
 	return;
 
-    QColor col = QColor::fromRgba(rgb);
     insertColor(col, tr("Custom"), -1);
     lastSel = col;
     emit selected(col);

--- a/qtcolorpicker/src/qtcolorpicker.h
+++ b/qtcolorpicker/src/qtcolorpicker.h
@@ -76,7 +76,7 @@ public:
 
     ~QtColorPicker();
 
-    void insertColor(const QColor &color, const QString &text = QString::null, int index = -1);
+    void insertColor(const QColor &color, const QString &text = QString(), int index = -1);
 
     QColor currentColor() const;
 


### PR DESCRIPTION
* QJsonDocument toBinaryData/fromBinaryData was removed; should probably
  migrate to QCbor eventually. Worked around for now.

* QString empty constructor replaces QString::null

* QWheelEvent delta() is deprecated, replaced with angleDelta() /
  pixelDelta()

* high-quality antialiasing hint is now included in default antialiasing option.

* QSet now accepts STL-like constructors.

* QSplashScreen no longer takes QWidget in constuctor.

* qSort replaced with std::sort

* QRegExp replaced with QRegularExpression.

* Bump C++ standard to 17 in CMakeLists.txt

* Setup CMakeLists to build with Qt6 if found, fallback to Qt5.

Apologies for the nasty megacommit. Tested very little, but it does build on both Qt5 and Qt6 for me, and it's a decent starting point nonetheless.

![image](https://user-images.githubusercontent.com/4522995/119240400-d6a7e700-bb14-11eb-8f9f-48d58836cc75.png)


